### PR TITLE
fix(2185): Use default_branch [1.5]

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function getRepoInfoByCheckoutUrl(checkoutUrl) {
     return {
         hostname: matched[MATCH_COMPONENT_HOSTNAME],
         reponame: matched[MATCH_COMPONENT_REPONAME],
-        branch: matched[MATCH_COMPONENT_BRANCH].slice(1),
+        branch: matched[MATCH_COMPONENT_BRANCH] ? matched[MATCH_COMPONENT_BRANCH].slice(1) : null,
         owner: matched[MATCH_COMPONENT_OWNER]
     };
 }
@@ -300,7 +300,9 @@ class GitlabScm extends Scm {
         }).then((response) => {
             checkResponseError(response, '_parseUrl');
 
-            return `${repoInfo.hostname}:${response.body.id}:${repoInfo.branch}`;
+            const branch = repoInfo.branch || response.body.default_branch;
+
+            return `${repoInfo.hostname}:${response.body.id}:${branch}`;
         });
     }
 
@@ -429,7 +431,7 @@ class GitlabScm extends Scm {
     /**
      * Decorate a given SCM URI with additional data to better display
      * related information. If a branch suffix is not provided, it will default
-     * to the master branch
+     * to the default_branch
      * @method _decorateUrl
      * @param  {Config}    config            Configuration object
      * @param  {String}    config.scmUri     The SCM URI the commit belongs to

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.6.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.7",
     "sinon-as-promised": "^4.0.2"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -100,7 +100,8 @@ describe('index', function () {
             fakeResponse = {
                 statusCode: 200,
                 body: {
-                    id: '12345'
+                    id: '12345',
+                    default_branch: 'main'
                 }
             };
             expectedOptions = {
@@ -129,6 +130,29 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'git@gitlab.com:batman/test.git#master',
+                token,
+                scmContext
+            }).then((parsed) => {
+                assert.calledWith(requestMock, expectedOptions);
+                assert.equal(parsed, expected);
+            });
+        });
+
+        it('resolves to the correct parsed url for ssh with default branch', () => {
+            const expected =
+                'gitlab.com:12345:main';
+
+            expectedOptions = {
+                url: apiUrl,
+                method: 'GET',
+                json: true,
+                auth: {
+                    bearer: token
+                }
+            };
+
+            return scm.parseUrl({
+                checkoutUrl: 'git@gitlab.com:batman/test.git',
                 token,
                 scmContext
             }).then((parsed) => {


### PR DESCRIPTION
## Context

Since we are removing setting default branch in API/UI, we will need to set it in the plugin.

## Objective

This PR sets the default branch to `default_branch` if not provided.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2185

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
