### PR TITLE
feat: upgrade hapiv19 dependencies. BREAKING CHANGE: new major data-schema version

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const Breaker = require('circuit-fuses').breaker;
 const Request = require('request');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
 const Schema = require('screwdriver-data-schema');
 const Scm = require('screwdriver-scm-base');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-scm-gitlab",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GitLab implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -35,18 +35,18 @@
     "chai": "^3.5.0",
     "eslint": "^4.6.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "mocha": "^8.1.1",
     "mockery": "^2.0.0",
     "sinon": "^1.17.7",
     "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "circuit-fuses": "^4.0.4",
-    "hoek": "^5.0.3",
-    "joi": "^13.0.0",
+    "joi": "^17.2.0",
     "request": "^2.80.0",
-    "screwdriver-data-schema": "^19.1.1",
-    "screwdriver-scm-base": "^6.0.0"
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-scm-base": "git://github.com/screwdriver-cd/scm-base.git#hapi-v19"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "circuit-fuses": "^4.0.4",
     "joi": "^17.2.0",
     "request": "^2.80.0",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
-    "screwdriver-scm-base": "git://github.com/screwdriver-cd/scm-base.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-scm-base": "^7.0.0"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
