### PR TITLE
fix(2398): URI encode path to file for getFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -771,7 +771,7 @@ class GitlabScm extends Scm {
                 bearer: token
             },
             url: `${this.config.gitlabProtocol}://${this.config.gitlabHost}/api/v4` +
-                 `/projects/${repoId}/repository/files/${fullPath}`,
+                 `/projects/${repoId}/repository/files/${encodeURIComponent(fullPath)}`,
             qs: {
                 ref: ref || branch
             }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "circuit-fuses": "^4.0.5",
     "joi": "^17.2.0",
     "request": "^2.80.0",
-    "screwdriver-data-schema": "^21.0.0",
+    "screwdriver-data-schema": "^21.2.7",
     "screwdriver-scm-base": "^7.0.0"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -874,7 +874,7 @@ describe('index', function () {
 
     describe('getFile', () => {
         const apiUrl = 'https://gitlab.com/api/v4/projects/repoId' +
-                       '/repository/files/path/to/file.txt';
+                       '/repository/files/path%2Fto%2Ffile.txt';
         let expectedOptions;
         let fakeResponse;
         let params;
@@ -917,7 +917,7 @@ describe('index', function () {
         it('resolves to correct commit sha when rootDir is passed in', () => {
             params.scmUri = 'hostName:repoId:branchName:path/to/source';
             expectedOptions.url = 'https://gitlab.com/api/v4/projects/repoId' +
-                           '/repository/files/path/to/source/path/to/file.txt';
+                           '/repository/files/path%2Fto%2Fsource%2Fpath%2Fto%2Ffile.txt';
 
             return scm.getFile(params).then((content) => {
                 assert.calledWith(requestMock, expectedOptions);


### PR DESCRIPTION
## Context

Gitlab requires the path to a file be URI encoded.

## Objective

This PR URI encodes the rootDir path.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2398

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
