### PR TITLE
fix(2437): Remove extra semicolon in get checkout command [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -463,7 +463,7 @@ class GitlabScm extends Scm {
 
         if (Hoek.reach(this.config, 'readOnly.enabled')) {
             if (Hoek.reach(this.config, 'readOnly.cloneType') === 'ssh') {
-                command.push(`export SCM_URL=${sshCheckoutUrl}; `);
+                command.push(`export SCM_URL=${sshCheckoutUrl}`);
             } else {
                 command.push('if [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
                     `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +


### PR DESCRIPTION
## Context

Getting errors with:
```
/bin/sh: 2: /tmp/step.sh: Syntax error: "&&" unexpected
```

## Objective

This PR removes extra semicolon from readOnly command.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437, https://github.com/screwdriver-cd/scm-gitlab/pull/41

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
