### PR TITLE
feat: Add state map changes for pending

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,14 +27,17 @@ const MATCH_COMPONENT_ROOTDIR = 5;
 const STATE_MAP = {
     SUCCESS: 'success',
     RUNNING: 'running',
-    QUEUED: 'pending'
+    QUEUED: 'pending',
+    PENDING: 'pending',
+    FAILURE: 'failed'
 };
 const DESCRIPTION_MAP = {
     SUCCESS: 'Everything looks good!',
     FAILURE: 'Did not work as expected.',
     ABORTED: 'Aborted mid-flight',
     RUNNING: 'Testing your code...',
-    QUEUED: 'Looking for a place to park...'
+    QUEUED: 'Looking for a place to park...',
+    PENDING: 'Parked it as Pending...'
 };
 
 /**
@@ -977,7 +980,7 @@ class GitlabScm extends Scm {
             qs: {
                 context: statusTitle,
                 description: description || DESCRIPTION_MAP[buildStatus],
-                state: STATE_MAP[buildStatus] || 'failure',
+                state: STATE_MAP[buildStatus] || 'failed',
                 target_url: url
             }
         }).then((response) => {

--- a/index.js
+++ b/index.js
@@ -26,17 +26,12 @@ const MATCH_COMPONENT_ROOTDIR = 5;
 
 const STATE_MAP = {
     SUCCESS: 'success',
-    RUNNING: 'running',
-    QUEUED: 'pending',
     PENDING: 'pending',
     FAILURE: 'failed'
 };
 const DESCRIPTION_MAP = {
     SUCCESS: 'Everything looks good!',
     FAILURE: 'Did not work as expected.',
-    ABORTED: 'Aborted mid-flight',
-    RUNNING: 'Testing your code...',
-    QUEUED: 'Looking for a place to park...',
     PENDING: 'Parked it as Pending...'
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1329,10 +1329,10 @@ describe('index', function () {
         );
 
         it('successfully update status with correct values', () => {
-            config.buildStatus = 'ABORTED';
+            config.buildStatus = 'FAILURE';
             expectedOptions.qs.context = 'Screwdriver/675/main';
             expectedOptions.qs.state = 'failed';
-            expectedOptions.qs.description = 'Aborted mid-flight';
+            expectedOptions.qs.description = 'Did not work as expected.';
 
             return scm.updateCommitStatus(config).then(() => {
                 assert.calledWith(requestMock, expectedOptions);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1331,7 +1331,7 @@ describe('index', function () {
         it('successfully update status with correct values', () => {
             config.buildStatus = 'ABORTED';
             expectedOptions.qs.context = 'Screwdriver/675/main';
-            expectedOptions.qs.state = 'failure';
+            expectedOptions.qs.state = 'failed';
             expectedOptions.qs.description = 'Aborted mid-flight';
 
             return scm.updateCommitStatus(config).then(() => {


### PR DESCRIPTION
## Context

Add Gitlab PR Status Mapping for PENDING status.

## Objective

SCM status checks should support PENDING status.

https://docs.screwdriver.cd/user-guide/metadata#additional-pull-request-checks need to support PENDING status

## References

Jira:
screwdriver-cd/screwdriver#2449

More related PRs:

screwdriver-cd/scm-github#189

screwdriver-cd/models#496

https://github.com/screwdriver-cd/models/pull/506

https://github.com/screwdriver-cd/scm-github/pull/190

https://github.com/screwdriver-cd/scm-gitlab/pull/43

https://github.com/screwdriver-cd/data-schema/pull/450

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
