### PR TITLE
Fix: Unauthorized users can be allowed to view the private pipeline if the logged-in user's scmContext and the pipeline's scmContext are different (scm-gitlab)

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,12 @@ class GitlabScm extends Scm {
     async lookupScmUri({ scmUri, token }) {
         const scmInfo = getScmUriParts(scmUri);
 
+        if (scmInfo.hostname !== this.config.gitlabHost) {
+            throw new Error(
+                `Pipeline's scmHost ${scmInfo.hostname} does not match with user's scmHost ${this.config.gitlabHost}`
+            );
+        }
+
         return this.breaker
             .runCommand({
                 method: 'GET',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Same with https://github.com/screwdriver-cd/scm-github/pull/194

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
