### PR TITLE
fix: Porting throwError function for proper error handling of parseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,16 +359,6 @@ class GitlabScm extends Scm {
                 token
             })
             .then(response => {
-                if (response.statusCode === 404) {
-                    throwError(`Cannot find repository ${checkoutUrl}`, response.statusCode);
-                }
-                if (response.statusCode !== 200) {
-                    throwError(
-                        `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`,
-                        response.statusCode
-                    );
-                }
-
                 const scmUri = `${hostname}:${response.body.id}:${branch || response.body.default_branch}`;
 
                 return sourceDir ? `${scmUri}:${sourceDir}` : scmUri;

--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ class GitlabScm extends Scm {
         if (hostname !== myHost) {
             const message = 'This checkoutUrl is not supported for your current login host.';
 
-            throwError(message, '400');
+            throwError(message, 400);
         }
 
         return this.breaker

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -259,6 +259,7 @@ describe('index', function() {
                     },
                     error => {
                         assert.match(error.message, expectedError);
+                        assert.match(error.statusCode, 400);
                     }
                 );
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Port the throwError function from scm-github so that the error handling of parseUrl can be done normally.
https://github.com/screwdriver-cd/scm-github/blob/e554b40619b8530d0eadc9ac02f35e3826900ff0/index.js#L57

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Error handling of parseUrl is successful

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/2674

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
