### PR TITLE
fix(2676): Add option to pass in checkoutUrl as path to getFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,25 +31,25 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.6",
     "eslint": "^7.31.0",
     "eslint-config-screwdriver": "^5.0.1",
     "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.0.0",
-    "nock": "^13.1.1",
+    "nock": "^13.2.4",
     "nyc": "^15.0.0",
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.2.0",
-    "circuit-fuses": "^4.1.0",
-    "joi": "^17.4.1",
-    "screwdriver-data-schema": "^21.7.0",
+    "@hapi/hoek": "^9.2.1",
+    "circuit-fuses": "^4.1.2",
+    "joi": "^17.6.0",
+    "screwdriver-data-schema": "^21.22.2",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-request": "^1.0.2",
-    "screwdriver-scm-base": "^7.3.0"
+    "screwdriver-scm-base": "^7.4.0"
   },
   "release": {
     "branches": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1001,6 +1001,24 @@ describe('index', function() {
             });
         });
 
+        it('resolves to correct commit sha when only full path is passed', () =>
+            scm
+                .getFile({
+                    scmUri: 'gitlab.com:146:master:src/app/component',
+                    path: 'https://ossmirror.vzbuilders.com/screwdriver-cd/scm-gitlab.git#master:path/to/a/file.yaml',
+                    token: 'somerandomtoken'
+                })
+                .then(content => {
+                    assert.deepEqual(content, 'dataValue');
+                    assert.calledWith(requestMock, {
+                        method: 'GET',
+                        searchParams: { ref: 'master' },
+                        url:
+                            'https://gitlab.com/api/v4/projects/screwdriver-cd%2Fscm-gitlab/repository/files/path%2Fto%2Fa%2Ffile.yaml',
+                        context: { token: 'somerandomtoken' }
+                    });
+                }));
+
         it('rejects if status code is not 200', () => {
             const err = new Error('404 Reason "Resource not found" Caller "_getFile"');
 
@@ -1479,7 +1497,7 @@ describe('index', function() {
                     type: 'pr',
                     token,
                     webhookConfig: null,
-                    scmUri: 'github.com:28476:master',
+                    scmUri: 'gitlab.com:28476:master',
                     prNum: 1
                 })
                 .then(result => {


### PR DESCRIPTION
## Context

In order to support getting provider config dynamically in screwdriver.yaml, we need to be able to pass in the full path to getFile instead of the scmUri, etc.

## Objective

This PR changes getFile method to allow using full path to get repo owner, name, branch, etc info.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2676
Related to https://github.com/screwdriver-cd/scm-github/pull/204

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
