### PR TITLE
feat(2695): Does not overwrite PR comment that from other PR job

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const Joi = require('joi');
 const Path = require('path');
 const Schema = require('screwdriver-data-schema');
 const CHECKOUT_URL_REGEX = Schema.config.regex.CHECKOUT_URL;
+const PR_COMMENTS_REGEX = /^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/;
 const Scm = require('screwdriver-scm-base');
 const logger = require('screwdriver-logger');
 const request = require('screwdriver-request');
@@ -904,10 +905,9 @@ class GitlabScm extends Scm {
             const botComment = prComments.comments.find(
                 commentObj =>
                     commentObj.author.username === this.config.username &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/) &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[1] ===
-                        pipelineId.toString() &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[2] === jobName
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX) &&
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[1] === pipelineId.toString() &&
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[2] === jobName
             );
 
             if (botComment) {

--- a/index.js
+++ b/index.js
@@ -895,14 +895,19 @@ class GitlabScm extends Scm {
      * @param  {String}   config.scmUri     The scmUri to get commit sha of
      * @return {Promise}
      */
-    async _addPrComment({ comment, prNum, scmUri }) {
+    async _addPrComment({ comment, jobName, prNum, scmUri, pipelineId }) {
         const { repoId } = getScmUriParts(scmUri);
 
         const prComments = await this.prComments(repoId, prNum);
 
         if (prComments) {
             const botComment = prComments.comments.find(
-                commentObj => commentObj.author.username === this.config.username
+                commentObj =>
+                    commentObj.author.username === this.config.username &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/) &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[1] ===
+                        pipelineId.toString() &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[2] === jobName
             );
 
             if (botComment) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@hapi/hoek": "^9.2.1",
     "circuit-fuses": "^4.1.2",
     "joi": "^17.6.0",
-    "screwdriver-data-schema": "^21.22.2",
+    "screwdriver-data-schema": "^21.24.0",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-request": "^1.0.2",
     "screwdriver-scm-base": "^7.4.0"

--- a/test/data/gitlab.merge_request.comments.json
+++ b/test/data/gitlab.merge_request.comments.json
@@ -1,8 +1,54 @@
 [
     {
+        "id": 575389132,
+        "type": null,
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main-2",
+        "attachment": null,
+        "author": {
+            "id": 8615742,
+            "name": "sd-buildbot",
+            "username": "sd-buildbot",
+            "state": "active",
+            "avatar_url": "https://assets.gitlab-static.net/uploads/-/system/user/avatar/8615742/avatar.png",
+            "web_url": "https://gitlab.com/sd-buildbot"
+        },
+        "created_at": "2021-05-13T22:55:03.477Z",
+        "updated_at": "2021-05-13T23:14:33.111Z",
+        "system": false,
+        "noteable_id": 21341086,
+        "noteable_type": "MergeRequest",
+        "resolvable": false,
+        "confidential": false,
+        "noteable_iid": 1,
+        "commands_changes": {}
+    },
+    {
+        "id": 575335839,
+        "type": null,
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/1/builds/133652) Job main",
+        "attachment": null,
+        "author": {
+            "id": 8615742,
+            "name": "sd-buildbot",
+            "username": "sd-buildbot",
+            "state": "active",
+            "avatar_url": "https://assets.gitlab-static.net/uploads/-/system/user/avatar/8615742/avatar.png",
+            "web_url": "https://gitlab.com/sd-buildbot"
+        },
+        "created_at": "2021-05-13T22:55:03.477Z",
+        "updated_at": "2021-05-13T23:14:33.111Z",
+        "system": false,
+        "noteable_id": 21341086,
+        "noteable_type": "MergeRequest",
+        "resolvable": false,
+        "confidential": false,
+        "noteable_iid": 1,
+        "commands_changes": {}
+    },
+    {
         "id": 575311268,
         "type": null,
-        "body": "**meow** EDIT *markdown*",
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main",
         "attachment": null,
         "author": {
             "id": 8615742,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -811,6 +811,8 @@ describe('index', function() {
         const apiUrl = 'projects/repoId/merge_requests/12345/notes';
         const comment = 'this is a merge request comment';
         const prNum = 12345;
+        const jobName = 'main';
+        const pipelineId = 123456;
         const expectedOptions = {
             url: `${prefixUrl}/${apiUrl}`,
             method: 'POST',
@@ -844,9 +846,11 @@ describe('index', function() {
             scm
                 .addPrComment({
                     comment,
+                    jobName,
                     prNum,
                     scmUri,
                     token,
+                    pipelineId,
                     scmContext
                 })
                 .then(result => {
@@ -865,9 +869,11 @@ describe('index', function() {
             return scm
                 .addPrComment({
                     comment,
+                    jobName,
                     prNum,
                     scmUri,
                     token,
+                    pipelineId,
                     scmContext
                 })
                 .then(result => {
@@ -908,9 +914,11 @@ describe('index', function() {
             return scm
                 .addPrComment({
                     comment,
+                    jobName,
                     prNum,
                     scmUri,
                     token,
+                    pipelineId,
                     scmContext
                 })
                 .then(data => {
@@ -936,9 +944,11 @@ describe('index', function() {
             return scm
                 .addPrComment({
                     comment,
+                    jobName,
                     prNum,
                     scmUri,
                     token,
+                    pipelineId,
                     scmContext
                 })
                 .then(data => {


### PR DESCRIPTION
## Context
If multiple jobs have PR comments, the later job's comment overwrites the earlier job's comment.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We change so that PR comments are only edited by the same job in the same pipeline.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://docs.gitlab.com/ee/api/notes.html
https://github.com/screwdriver-cd/screwdriver/issues/2695
Reflect the following PRs before reflecting this.
- https://github.com/screwdriver-cd/data-schema/pull/489
- https://github.com/screwdriver-cd/models/pull/543
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
