### PR TITLE
feat(2873): allow user to split pr comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -902,8 +902,9 @@ class GitlabScm extends Scm {
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX) &&
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[1] === pipelineId.toString() &&
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[2] === jobName &&
-                        commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX) &&
-                        commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX)[1] === comment.keyWord
+                        (!comment.keyWord ||
+                            (commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX) &&
+                                commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX)[1] === comment.keyWord))
                 );
             }
 

--- a/index.js
+++ b/index.js
@@ -902,9 +902,9 @@ class GitlabScm extends Scm {
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX) &&
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[1] === pipelineId.toString() &&
                         commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[2] === jobName &&
-                        (!comment.keyWord ||
+                        (!comment.keyword ||
                             (commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX) &&
-                                commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX)[1] === comment.keyWord))
+                                commentObj.body.split(/\n/)[3].match(PR_COMMENTS_KEYWORD_REGEX)[1] === comment.keyword))
                 );
             }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "screwdriver-data-schema": "^22.0.1",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-request": "^2.0.1",
-    "screwdriver-scm-base": "^8.0.1"
+    "screwdriver-scm-base": "^8.1.0"
   },
   "release": {
     "branches": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "screwdriver-data-schema": "^22.0.1",
     "screwdriver-logger": "^2.0.0",
     "screwdriver-request": "^2.0.1",
-    "screwdriver-scm-base": "^8.0.0"
+    "screwdriver-scm-base": "^8.0.1"
   },
   "release": {
     "branches": [

--- a/test/data/gitlab.merge_request.comments.json
+++ b/test/data/gitlab.merge_request.comments.json
@@ -2,7 +2,7 @@
     {
         "id": 575389132,
         "type": null,
-        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main-2",
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main-2\n_node:18_\n- - - -\n__bar__ - Coverage increased by 20%",
         "attachment": null,
         "author": {
             "id": 8615742,
@@ -25,7 +25,7 @@
     {
         "id": 575335839,
         "type": null,
-        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/1/builds/133652) Job main",
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main\n_node:18_\n- - - -\n__bar__ - Coverage increased by 20%",
         "attachment": null,
         "author": {
             "id": 8615742,
@@ -48,7 +48,7 @@
     {
         "id": 575311268,
         "type": null,
-        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main",
+        "body": "### SD Build [#133652](https://cd.screwdriver.cd/pipelines/123456/builds/133652) Job main\n_node:18_\n- - - -\n__foo__ - Coverage increased by 20%",
         "attachment": null,
         "author": {
             "id": 8615742,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -910,8 +910,8 @@ describe('index', function () {
 
         it('creats multiple comments', () => {
             const multipleComments = [
-                { text: 'this was a great PR', keyWord: 'foos' },
-                { text: 'this was not a great PR', keyWord: 'bars' }
+                { text: 'this was a great PR', keyword: 'foos' },
+                { text: 'this was not a great PR', keyword: 'bars' }
             ];
 
             requestMock.onFirstCall().resolves(fakeCommentsResponse);
@@ -973,8 +973,8 @@ describe('index', function () {
 
         it('edits multiple comments', () => {
             const multipleComments = [
-                { text: 'this was a great PR', keyWord: 'foo' },
-                { text: 'this was not a great PR', keyWord: 'bar' }
+                { text: 'this was a great PR', keyword: 'foo' },
+                { text: 'this was not a great PR', keyword: 'bar' }
             ];
 
             requestMock.onFirstCall().resolves(fakeCommentsResponse);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -809,7 +809,7 @@ describe('index', function () {
 
     describe('addPrComment', () => {
         const apiUrl = 'projects/repoId/merge_requests/12345/notes';
-        const comment = 'this is a merge request comment';
+        const comments = [{ text: 'this was a great PR', keyWord: 'foo' }];
         const prNum = 12345;
         const jobName = 'main';
         const pipelineId = 123456;
@@ -820,7 +820,7 @@ describe('index', function () {
                 token: commentUserToken
             },
             json: {
-                body: comment
+                body: comments[0].text
             }
         };
         let fakeResponse;
@@ -845,7 +845,7 @@ describe('index', function () {
         it('resolves to correct PR metadata', () =>
             scm
                 .addPrComment({
-                    comment,
+                    comments,
                     jobName,
                     prNum,
                     scmUri,
@@ -854,12 +854,15 @@ describe('index', function () {
                     scmContext
                 })
                 .then(result => {
+                    assert.calledTwice(requestMock);
                     assert.calledWith(requestMock.secondCall, expectedOptions);
-                    assert.deepEqual(result, {
-                        commentId: 126861726,
-                        createTime: '2018-12-21T20:33:33.157Z',
-                        username: 'tkyi'
-                    });
+                    assert.deepEqual(result, [
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        }
+                    ]);
                 }));
 
         it('resolves to correct PR metadata for edited comment', () => {
@@ -868,7 +871,119 @@ describe('index', function () {
 
             return scm
                 .addPrComment({
-                    comment,
+                    comments,
+                    jobName,
+                    prNum,
+                    scmUri,
+                    token,
+                    pipelineId,
+                    scmContext
+                })
+                .then(result => {
+                    assert.calledTwice(requestMock);
+                    assert.calledWith(requestMock.firstCall, {
+                        url: `${prefixUrl}/${apiUrl}`,
+                        method: 'GET',
+                        context: {
+                            token: commentUserToken
+                        }
+                    });
+                    assert.calledWith(requestMock.secondCall, {
+                        url: `${prefixUrl}/${apiUrl}/575311268`,
+                        method: 'PUT',
+                        context: {
+                            token: commentUserToken
+                        },
+                        json: {
+                            body: 'this was a great PR'
+                        }
+                    });
+                    assert.deepEqual(result, [
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        }
+                    ]);
+                });
+        });
+
+        it('creats multiple comments', () => {
+            const multipleComments = [
+                { text: 'this was a great PR', keyWord: 'foos' },
+                { text: 'this was not a great PR', keyWord: 'bars' }
+            ];
+
+            requestMock.onFirstCall().resolves(fakeCommentsResponse);
+            requestMock.onSecondCall().resolves(fakeResponse);
+            requestMock.onThirdCall().resolves(fakeResponse);
+
+            return scm
+                .addPrComment({
+                    comments: multipleComments,
+                    jobName,
+                    prNum,
+                    scmUri,
+                    token,
+                    pipelineId,
+                    scmContext
+                })
+                .then(result => {
+                    assert.calledWith(requestMock.firstCall, {
+                        url: `${prefixUrl}/${apiUrl}`,
+                        method: 'GET',
+                        context: {
+                            token: commentUserToken
+                        }
+                    });
+                    assert.calledWith(requestMock.secondCall, {
+                        url: `${prefixUrl}/${apiUrl}`,
+                        method: 'POST',
+                        context: {
+                            token: commentUserToken
+                        },
+                        json: {
+                            body: 'this was a great PR'
+                        }
+                    });
+                    assert.calledWith(requestMock.thirdCall, {
+                        url: `${prefixUrl}/${apiUrl}`,
+                        method: 'POST',
+                        context: {
+                            token: commentUserToken
+                        },
+                        json: {
+                            body: 'this was not a great PR'
+                        }
+                    });
+                    assert.deepEqual(result, [
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        },
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        }
+                    ]);
+                });
+        });
+
+        it('edits multiple comments', () => {
+            const multipleComments = [
+                { text: 'this was a great PR', keyWord: 'foo' },
+                { text: 'this was not a great PR', keyWord: 'bar' }
+            ];
+
+            requestMock.onFirstCall().resolves(fakeCommentsResponse);
+            requestMock.onSecondCall().resolves(fakeResponse);
+            requestMock.onThirdCall().resolves(fakeResponse);
+
+            return scm
+                .addPrComment({
+                    comments: multipleComments,
                     jobName,
                     prNum,
                     scmUri,
@@ -891,18 +1006,35 @@ describe('index', function () {
                             token: commentUserToken
                         },
                         json: {
-                            body: 'this is a merge request comment'
+                            body: 'this was a great PR'
                         }
                     });
-                    assert.deepEqual(result, {
-                        commentId: 126861726,
-                        createTime: '2018-12-21T20:33:33.157Z',
-                        username: 'tkyi'
+                    assert.calledWithMatch(requestMock, {
+                        url: `${prefixUrl}/${apiUrl}/575335839`,
+                        method: 'PUT',
+                        context: {
+                            token: commentUserToken
+                        },
+                        json: {
+                            body: 'this was not a great PR'
+                        }
                     });
+                    assert.deepEqual(result, [
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        },
+                        {
+                            commentId: 126861726,
+                            createTime: '2018-12-21T20:33:33.157Z',
+                            username: 'tkyi'
+                        }
+                    ]);
                 });
         });
 
-        it('resolves null if status code is not 200', () => {
+        it('resolves empty array if status code is not 200', () => {
             fakeResponse = {
                 statusCode: 404,
                 body: {
@@ -913,7 +1045,7 @@ describe('index', function () {
 
             return scm
                 .addPrComment({
-                    comment,
+                    comments,
                     jobName,
                     prNum,
                     scmUri,
@@ -922,7 +1054,7 @@ describe('index', function () {
                     scmContext
                 })
                 .then(data => {
-                    assert.isNull(data);
+                    assert.isEmpty(data);
                 })
                 .catch(error => {
                     assert.calledWith(requestMock, expectedOptions);
@@ -931,7 +1063,7 @@ describe('index', function () {
                 });
         });
 
-        it('resolves null if status code is not 200 for edited comment', () => {
+        it('resolves empty array if status code is not 200 for edited comment', () => {
             fakeResponse = {
                 statusCode: 404,
                 body: {
@@ -943,7 +1075,7 @@ describe('index', function () {
 
             return scm
                 .addPrComment({
-                    comment,
+                    comments,
                     jobName,
                     prNum,
                     scmUri,
@@ -952,7 +1084,7 @@ describe('index', function () {
                     scmContext
                 })
                 .then(data => {
-                    assert.isNull(data);
+                    assert.isEmpty(data);
                 })
                 .catch(error => {
                     assert.calledWith(requestMock, expectedOptions);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -809,7 +809,7 @@ describe('index', function () {
 
     describe('addPrComment', () => {
         const apiUrl = 'projects/repoId/merge_requests/12345/notes';
-        const comments = [{ text: 'this was a great PR', keyWord: 'foo' }];
+        const comments = [{ text: 'this was a great PR' }];
         const prNum = 12345;
         const jobName = 'main';
         const pipelineId = 123456;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -889,7 +889,7 @@ describe('index', function () {
                         }
                     });
                     assert.calledWith(requestMock.secondCall, {
-                        url: `${prefixUrl}/${apiUrl}/575311268`,
+                        url: `${prefixUrl}/${apiUrl}/575335839`,
                         method: 'PUT',
                         context: {
                             token: commentUserToken


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
allow user to split pr comment into different ones
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2873
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
