### PR TITLE
feat(2892): get GitLab user ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,6 +721,7 @@ class GitlabScm extends Scm {
                 });
 
                 return {
+                    id: author.id,
                     url: author.web_url,
                     name: author.name,
                     username: author.username,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -432,6 +432,7 @@ describe('index', function () {
 
         it('resolves to correct decorated author', () => {
             const expected = {
+                id: 12345,
                 url: 'https://gitlab.com/batman',
                 name: 'Batman',
                 username: 'batman',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The following PR needs to get a SCM user id.
https://github.com/screwdriver-cd/screwdriver/pull/2890

This PR will include a GitLab id in the return value of `decorateAuthor`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will add a GitLab id in the return value of `decorateAuthor`.

I cannot actually test this by GitLab API, so try this please.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue

- https://github.com/screwdriver-cd/screwdriver/issues/2892

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
