### PR TITLE
fix(2892): normalize the type of GitLab user id to String

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,7 +721,7 @@ class GitlabScm extends Scm {
                 });
 
                 return {
-                    id: author.id,
+                    id: author.id.toString(),
                     url: author.web_url,
                     name: author.name,
                     username: author.username,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -432,7 +432,7 @@ describe('index', function () {
 
         it('resolves to correct decorated author', () => {
             const expected = {
-                id: 12345,
+                id: '12345',
                 url: 'https://gitlab.com/batman',
                 name: 'Batman',
                 username: 'batman',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up of PR https://github.com/screwdriver-cd/scm-gitlab/pull/57

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR normalize the type of GitLab user id to String.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2892#issuecomment-1602452632

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
