### PR TITLE
fix(3225): organize the return values of _parseHook [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,6 +376,10 @@ class GitlabScm extends Scm {
         const commits = Hoek.reach(webhookPayload, 'commits');
         const type = Hoek.reach(webhookPayload, 'object_kind');
 
+        if (!Object.keys(payloadHeaders).includes('x-gitlab-event')) {
+            throwError('Missing x-gitlab-event header', 400);
+        }
+
         switch (type) {
             case 'merge_request': {
                 const mergeRequest = Hoek.reach(webhookPayload, 'object_attributes');
@@ -1234,16 +1238,10 @@ class GitlabScm extends Scm {
      * @return {Promise}
      */
     async _canHandleWebhook(headers, payload) {
-        if (!Object.keys(headers).includes('x-gitlab-event')) {
-            logger.error('Failed to run canHandleWebhook');
-
-            return Promise.resolve(false);
-        }
-
         try {
-            const result = await this._parseHook(headers, payload);
+            await this._parseHook(headers, payload);
 
-            return result !== null;
+            return true;
         } catch (err) {
             logger.error('Failed to run canHandleWebhook', err);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -367,7 +367,7 @@ describe('index', function () {
 
         it('resolves null if events are not supported: repoFork', () => {
             const repoFork = {
-                'x-event-key': 'repo:fork'
+                'x-gitlab-event': 'repo:fork'
             };
 
             return scm.parseHook(repoFork, {}).then(result => assert.deepEqual(result, null));
@@ -375,7 +375,7 @@ describe('index', function () {
 
         it('resolves null if events are not supported: prComment', () => {
             const prComment = {
-                'x-event-key': 'pullrequest:comment_created'
+                'x-gitlab-event': 'Note Hook'
             };
 
             return scm.parseHook(prComment, {}).then(result => assert.deepEqual(result, null));
@@ -383,7 +383,7 @@ describe('index', function () {
 
         it('resolves null if events are not supported: issueCreated', () => {
             const issueCreated = {
-                'x-event-key': 'issue:created'
+                'x-gitlab-event': 'Issue Hook'
             };
 
             return scm.parseHook(issueCreated, {}).then(result => assert.deepEqual(result, null));
@@ -2184,7 +2184,7 @@ describe('index', function () {
             scm._parseHook.resolves(null);
 
             return scm.canHandleWebhook(headers, testPayloadOpen).then(result => {
-                assert.strictEqual(result, false);
+                assert.strictEqual(result, true);
             });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2174,7 +2174,7 @@ describe('index', function () {
             });
         });
 
-        it('returns a false when parseHook resolves null', () => {
+        it('returns a true when parseHook resolves null', () => {
             const headers = {
                 'content-type': 'application/json',
                 'x-gitlab-event': 'Push Hook'


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the `_parseHook` method  returns Object or null or throw Error.
However, their return values are not properly conditioned.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Organize the return values by the following:

- return Object (parsed result): the `scm` is correct and Screwdriver do actions with the webhook (e.g. `push` event)
- return null: the `scm` is correct and Screwdriver do nothing (e.g. `delete` event)
- throw Error: the `scm` is not correct

Then we can handle whether the webhook is correct or not at [here](https://github.com/screwdriver-cd/screwdriver/blob/ef31fca55eaff2548f7486795de41e84f87a675d/plugins/webhooks/index.js#L68-L73).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3225

PR
- https://github.com/screwdriver-cd/scm-router/pull/37

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
