### PR TITLE
feat: add prMerged to parsed webhook response

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,6 +389,7 @@ class GitlabScm extends Scm {
                 const baseSource = Hoek.reach(mergeRequest, 'target_project_id');
                 const headSource = Hoek.reach(mergeRequest, 'source_project_id');
                 const prSource = baseSource === headSource ? 'branch' : 'fork';
+                const prMerged = action === 'merged';
                 const ref = `pull/${prNum}/merge`;
 
                 // Possible actions
@@ -414,7 +415,8 @@ class GitlabScm extends Scm {
                     type: 'pr',
                     username: Hoek.reach(webhookPayload, 'user.username'),
                     hookId,
-                    scmContext
+                    scmContext,
+                    prMerged
                 };
             }
             case 'push': {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -282,7 +282,8 @@ describe('index', function () {
                 prTitle: 'fix tabby cat',
                 ref: 'pull/6/merge',
                 hookId: '',
-                scmContext
+                scmContext,
+                prMerged: false
             };
             const headers = {
                 'content-type': 'application/json',
@@ -306,7 +307,8 @@ describe('index', function () {
                 prTitle: 'Fix this stuff',
                 ref: 'pull/2/merge',
                 hookId: '',
-                scmContext
+                scmContext,
+                prMerged: true
             };
             const headers = {
                 'content-type': 'application/json',
@@ -330,7 +332,8 @@ describe('index', function () {
                 prTitle: 'Fix this stuff',
                 ref: 'pull/2/merge',
                 hookId: '',
-                scmContext
+                scmContext,
+                prMerged: true
             };
             const headers = {
                 'content-type': 'application/json',


### PR DESCRIPTION
## Context

SD configuration currently does not support pull_request closed trigger, to enable this feature we need to additional parsed information from webhook

## Objective

This PR adds `prMerged` flag to parsed webhook response

## References

https://github.com/screwdriver-cd/data-schema/pull/597

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
