### PR TITLE
feat: use default avatar when avatar_url is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -741,7 +741,7 @@ class GitlabScm extends Scm {
                     url: author.web_url,
                     name: author.name,
                     username: author.username,
-                    avatar: author.avatar_url
+                    avatar: author.avatar_url || DEFAULT_AUTHOR.avatar
                 };
             });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -454,6 +454,42 @@ describe('index', function () {
                 });
         });
 
+        it('resolves to correct decorated author when avatar_url is not present', () => {
+            const fakeResponse1 = {
+                statusCode: 200,
+                body: [
+                    {
+                        username: 'batman',
+                        name: 'Batman',
+                        id: 12345,
+                        state: 'active',
+                        web_url: 'https://gitlab.com/batman'
+                    }
+                ]
+            };
+
+            requestMock.resolves(fakeResponse1);
+
+            const expected = {
+                id: '12345',
+                url: 'https://gitlab.com/batman',
+                name: 'Batman',
+                username: 'batman',
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png'
+            };
+
+            return scm
+                .decorateAuthor({
+                    username: 'batman',
+                    scmContext,
+                    token
+                })
+                .then(decorated => {
+                    assert.calledWith(requestMock, expectedOptions);
+                    assert.deepEqual(decorated, expected);
+                });
+        });
+
         it('rejects if status code is not 200', () => {
             const err = new Error('404 Reason "Resource not found" Caller "_decorateAuthor"');
 


### PR DESCRIPTION
## Context

Event start fails validation when `avatar_url` property is undefined.

## Objective

This PR uses default `avatar` for the commit `author` object

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
