### PR TITLE
fix(3384): Failure to get user info from scm should not throw error

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-request": "^3.0.0",
-    "screwdriver-scm-base": "^10.0.0"
+    "screwdriver-scm-base": "^10.0.1"
   },
   "release": {
     "branches": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -490,7 +490,7 @@ describe('index', function () {
                 });
         });
 
-        it('rejects if status code is not 200', () => {
+        it('resolves with author with default values for the optional fields if status code is not 200', () => {
             const err = new Error('404 Reason "Resource not found" Caller "_decorateAuthor"');
 
             err.status = 404;
@@ -503,17 +503,21 @@ describe('index', function () {
                     scmContext,
                     token
                 })
-                .then(() => {
-                    assert.fail('Should not get here');
-                })
-                .catch(error => {
-                    assert.calledWith(requestMock, expectedOptions);
-                    assert.match(error.message, '404 Reason "Resource not found" Caller "_decorateAuthor"');
-                    assert.match(error.status, 404);
+                .then(author => {
+                    assert.deepEqual(
+                        {
+                            id: '',
+                            avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                            name: 'batman',
+                            username: 'batman',
+                            url: 'https://cd.screwdriver.cd/'
+                        },
+                        author
+                    );
                 });
         });
 
-        it('rejects if fails', () => {
+        it('resolves with author with default values for the optional fields when there is a failure', () => {
             const err = new Error('500 Reason "Internal Server Error" Caller "_decorateAuthor"');
 
             err.status = 500;
@@ -526,11 +530,17 @@ describe('index', function () {
                     scmContext,
                     token
                 })
-                .then(() => {
-                    assert.fail('Should not get here');
-                })
-                .catch(error => {
-                    assert.equal(error, err);
+                .then(author => {
+                    assert.deepEqual(
+                        {
+                            id: '',
+                            avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                            name: 'batman',
+                            username: 'batman',
+                            url: 'https://cd.screwdriver.cd/'
+                        },
+                        author
+                    );
                 });
         });
     });


### PR DESCRIPTION
## Context

Changes made in the https://github.com/screwdriver-cd/scm-base/pull/101 has resulted in few test failures

## Objective

Adapt the tests to align with the latest changes

## References

https://github.com/screwdriver-cd/screwdriver/issues/3384

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
