### PR TITLE
fix: Verify signature of payloads containing control characters [3]

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -290,7 +290,9 @@ describe('index', function () {
                 'x-gitlab-event': 'Merge Request Hook'
             };
 
-            return scm.parseHook(headers, testPayloadOpen).then(result => assert.deepEqual(result, expected));
+            return scm
+                .parseHook(headers, JSON.stringify(testPayloadOpen))
+                .then(result => assert.deepEqual(result, expected));
         });
 
         it('resolves the correct parsed config for closed PR after merged', () => {
@@ -315,7 +317,9 @@ describe('index', function () {
                 'x-gitlab-event': 'Merge Request Hook'
             };
 
-            return scm.parseHook(headers, testPayloadClose).then(result => assert.deepEqual(result, expected));
+            return scm
+                .parseHook(headers, JSON.stringify(testPayloadClose))
+                .then(result => assert.deepEqual(result, expected));
         });
 
         it('resolves the correct parsed config for closed PR after declined', () => {
@@ -340,7 +344,9 @@ describe('index', function () {
                 'x-gitlab-event': 'Merge Request Hook'
             };
 
-            return scm.parseHook(headers, testPayloadClose).then(result => assert.deepEqual(result, expected));
+            return scm
+                .parseHook(headers, JSON.stringify(testPayloadClose))
+                .then(result => assert.deepEqual(result, expected));
         });
 
         it('resolves the correct parsed config for push to repo event', () => {
@@ -365,7 +371,9 @@ describe('index', function () {
                 'x-gitlab-event': 'Push Hook'
             };
 
-            return scm.parseHook(headers, testPayloadPush).then(result => assert.deepEqual(result, expected));
+            return scm
+                .parseHook(headers, JSON.stringify(testPayloadPush))
+                .then(result => assert.deepEqual(result, expected));
         });
 
         it('resolves null if events are not supported: repoFork', () => {
@@ -373,7 +381,7 @@ describe('index', function () {
                 'x-gitlab-event': 'repo:fork'
             };
 
-            return scm.parseHook(repoFork, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(repoFork, JSON.stringify({})).then(result => assert.deepEqual(result, null));
         });
 
         it('resolves null if events are not supported: prComment', () => {
@@ -381,7 +389,7 @@ describe('index', function () {
                 'x-gitlab-event': 'Note Hook'
             };
 
-            return scm.parseHook(prComment, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(prComment, JSON.stringify({})).then(result => assert.deepEqual(result, null));
         });
 
         it('resolves null if events are not supported: issueCreated', () => {
@@ -389,7 +397,7 @@ describe('index', function () {
                 'x-gitlab-event': 'Issue Hook'
             };
 
-            return scm.parseHook(issueCreated, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(issueCreated, JSON.stringify({})).then(result => assert.deepEqual(result, null));
         });
 
         it('resolves null for a pull request payload with an unsupported action', () => {
@@ -398,7 +406,9 @@ describe('index', function () {
                 action: 'locked'
             };
 
-            return scm.parseHook(testHeaders, { object_kind: 'merge_request' }).then(result => assert.isNull(result));
+            return scm
+                .parseHook(testHeaders, JSON.stringify({ object_kind: 'merge_request' }))
+                .then(result => assert.isNull(result));
         });
     });
 
@@ -2184,7 +2194,7 @@ describe('index', function () {
                 'x-gitlab-event': 'Merge Request Hook'
             };
 
-            return scm.canHandleWebhook(headers, testPayloadOpen).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadOpen)).then(result => {
                 assert.strictEqual(result, true);
             });
         });
@@ -2195,7 +2205,7 @@ describe('index', function () {
                 'x-gitlab-event': 'Merge Request Hook'
             };
 
-            return scm.canHandleWebhook(headers, testPayloadClose).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadClose)).then(result => {
                 assert.strictEqual(result, true);
             });
         });
@@ -2206,7 +2216,7 @@ describe('index', function () {
                 'x-gitlab-event': 'Push Hook'
             };
 
-            return scm.canHandleWebhook(headers, testPayloadPush).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadPush)).then(result => {
                 assert.strictEqual(result, true);
             });
         });
@@ -2218,7 +2228,7 @@ describe('index', function () {
                 'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
             };
 
-            return scm.canHandleWebhook(headers, testPayloadOpen).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadOpen)).then(result => {
                 assert.strictEqual(result, false);
             });
         });
@@ -2232,7 +2242,7 @@ describe('index', function () {
             scm._parseHook = sinon.stub();
             scm._parseHook.resolves(null);
 
-            return scm.canHandleWebhook(headers, testPayloadOpen).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadOpen)).then(result => {
                 assert.strictEqual(result, true);
             });
         });
@@ -2245,7 +2255,7 @@ describe('index', function () {
 
             scm._parseHook = sinon.stub().rejects();
 
-            return scm.canHandleWebhook(headers, testPayloadOpen).then(result => {
+            return scm.canHandleWebhook(headers, JSON.stringify(testPayloadOpen)).then(result => {
                 assert.strictEqual(result, false);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When JSON.stringify() is applied to certain control characters, their character representation changes.

```
> JSON.stringify({x: '\u001F'})
'{"x":"\\u001f"}'
> JSON.stringify({x: '\x1F'})
'{"x":"\\u001f"}'
```

Therefore, if you use the value obtained by re-stringifying the payload after JSON.parse for verifying the signature, it will fail because the contents do not match.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- The original payload will be used for signature verification.
- Enable passing the string before parsing to the _parseHook in scm components.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- https://github.com/screwdriver-cd/scm-base/pull/102
- https://github.com/screwdriver-cd/scm-github/pull/250
- https://github.com/screwdriver-cd/scm-gitlab/pull/74
- https://github.com/screwdriver-cd/scm-bitbucket/pull/102
- https://github.com/screwdriver-cd/scm-router/pull/39
- https://github.com/screwdriver-cd/screwdriver/pull/3407

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
